### PR TITLE
check if result url does exist before parsing

### DIFF
--- a/speedtest.py
+++ b/speedtest.py
@@ -104,7 +104,11 @@ def run_speedtest():
         ping_latency = round(float(st_results["ping"]["latency"]),2)
         isp = st_results["isp"]
         server_name = st_results["server"]["name"]
-        url_result = st_results["result"]["url"]
+        url_persisted = st_results["result"]["persisted"]
+        if url_persisted:
+            url_result = st_results["result"]["url"]
+        else:
+            url_result = ""
         server_id = st_results["server"]["id"]
         timestamp = st_results["timestamp"]
         


### PR DESCRIPTION
Sometimes the result from Speedtest result doesn't contain the field url, causing for the script to fail and exit the loop,

```
"result":{"id":"2624f52e-aeb1-4ef1-a349-6dc24f877a68","persisted":false}
```
```
Stderr: 
Traceback (most recent call last):
  File "/usr/src/app/test.py", line 288, in <module>
    run_speedtest()
  File "/usr/src/app/test.py", line 108, in run_speedtest
    id_result = st_results["result"]["url"]
                ~~~~~~~~~~~~~~~~~~~~^^^^^^^
KeyError: 'url'
```
