### PR TITLE
naming of MQTT entities changes to correspond with HA guidelines

### DIFF
--- a/speedtest.py
+++ b/speedtest.py
@@ -171,7 +171,8 @@ def send_autodiscover(name, entity_id, entity_type, state_topic = None, device_c
     sensor_unique_id = HAAutoDiscoveryDeviceId + "-" + entity_id
 
     discovery_message = {
-        "name": HAAutoDiscoveryDeviceName + " " + name,
+        "name": name,
+        "has_entity_name": True,
         "availability_topic":HAAutoDiscoveryDeviceId+"/status",
         "payload_available":"online",
         "payload_not_available":"offline",


### PR DESCRIPTION
To align to the guidelines https://developers.home-assistant.io/blog/2023-057-21-change-naming-mqtt-entities/